### PR TITLE
Additional features needed for Expo 53 project using CNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ A lightweight, unrestricted alternative for creating NSE with Expo under a stand
 
 ## Provisioning profiles
 
-This plugin **does not** handle anything related to the signing process and does not automate the process of choosing the provisioning profile for the NSE target. For this purpose it's probably best if you use Expo Application Services and its [multitarget configuration](https://docs.expo.dev/app-signing/local-credentials/#multi-target-project).
+The developer team will be copied from your `app.json` into the Notification Service Extension, so if your Xcode project "Automatically manage[s] signing" this may be sufficient to sign it.  
+Otherwise, this plugin **does nothing else** related to the signing process and does not automate the process of choosing the provisioning profile for the NSE target. For this purpose it's probably best if you use Expo Application Services and its [multitarget configuration](https://docs.expo.dev/app-signing/local-credentials/#multi-target-project).
 
 # Installation and usage
 
@@ -70,6 +71,10 @@ Advanced:
             "mFilePath": "./my_path/to_a_custom_nse_implementation_file", // or array of filepaths
             "hFilePath": "./my_path/to_a_custom_nse_header_file", // or array of filepaths
             "bundleName": "NotificationServiceExtension",
+            "frameworks": ["Intents.framework"],
+            "extraBuildSettings": {
+              "OTHER_LDFLAGS": "$(inherited) -lstdc++"
+            }
           }
         }
       ]
@@ -82,17 +87,19 @@ Advanced:
 
 All the options of the plugin configurable from the `app.json` / `app.config.js` file are listed below:
 
-| **Property**                              | **Type**                        | **Required** | **Default**                      | **Description**                                                                                                   |
-| ----------------------------------------- | ------------------------------- | ------------ | -------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `mode`                                    | `"development" \| "production"` | No           | `"development"`                  | Determines the APNs environment. Use `development` for testing and `production` for App Store builds              |
-| `appGroup`                                | `string`                        | No           | None                             | The App Group identifier used to share data between the main app and the NSE. Format: `group.your.bundle.id`      |
-| `backgroundModes.remoteNotifications`     | `boolean`                       | No           | `true`                           | Enables remote notifications background mode in your app's capabilities (if set to false, keeps as-is)            |
-| `backgroundModes.fetch`                   | `boolean`                       | No           | `false`                          | Enables background fetch capability in your app's capabilities (if set to false, keeps as-is)                     |
-| `appDelegate.remoteNotificationsDelegate` | `string`                        | No           | None                             | Custom code to be injected into the `didRegisterForRemoteNotificationsWithDeviceToken` method of your AppDelegate |
-| `appDelegate.imports`                     | `string \| string[]`            | No           | None                             | Additional import statements to be added to your AppDelegate                                                      |
-| `nse.mFilePath`                           | `string \| string[]`            | No           | Default Xcode's NSE content      | Path to a custom implementation file (.m) for the Notification Service Extension                                  |
-| `nse.hFilePath`                           | `string \| string[]`            | No           | Default Xcode's NSE content      | Path to a custom header file (.h) for the Notification Service Extension                                          |
-| `nse.bundleName`                          | `string`                        | No           | `"NotificationServiceExtension"` | The name of your Notification Service Extension target                                                            |
+| **Property**                              | **Type**                        | **Required** | **Default**                      | **Description**                                                                                                         |
+|-------------------------------------------|---------------------------------|--------------|----------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `mode`                                    | `"development" \| "production"` | No           | `"development"`                  | Determines the APNs environment. Use `development` for testing and `production` for App Store builds                    |
+| `appGroup`                                | `string`                        | No           | None                             | The App Group identifier used to share data between the main app and the NSE. Format: `group.your.bundle.id`            |
+| `backgroundModes.remoteNotifications`     | `boolean`                       | No           | `true`                           | Enables remote notifications background mode in your app's capabilities (if set to false, keeps as-is)                  |
+| `backgroundModes.fetch`                   | `boolean`                       | No           | `false`                          | Enables background fetch capability in your app's capabilities (if set to false, keeps as-is)                           |
+| `appDelegate.remoteNotificationsDelegate` | `string`                        | No           | None                             | Custom code to be injected into the `didRegisterForRemoteNotificationsWithDeviceToken` method of your AppDelegate       |
+| `appDelegate.imports`                     | `string \| string[]`            | No           | None                             | Additional import statements to be added to your AppDelegate                                                            |
+| `nse.mFilePath`                           | `string \| string[]`            | No           | Default Xcode's NSE content      | Path to a custom implementation file (.m) for the Notification Service Extension                                        |
+| `nse.hFilePath`                           | `string \| string[]`            | No           | Default Xcode's NSE content      | Path to a custom header file (.h) for the Notification Service Extension                                                |
+| `nse.bundleName`                          | `string`                        | No           | `"NotificationServiceExtension"` | The name of your Notification Service Extension target                                                                  |
+| `nse.frameworks`                          | `string[]`                      | No           | None                             | Additional iOS Frameworks to link with the Notification Service Extension (UserNotifications.framework always included) |
+| `nse.extraBuildSettings`                  | `object`                        | No           | None                             | Additional keys/values to add to the Notification Service Extension's build settings                                    |
 
 # Contributing & testing
 

--- a/plugin/src/ios.ts
+++ b/plugin/src/ios.ts
@@ -135,7 +135,7 @@ const withNseTarget: ConfigPlugin<PluginProps> = (
   config,
   { nse, appGroup }
 ) => {
-  const { bundleName, hFilePath, mFilePath } = nse;
+  const { bundleName, hFilePath, mFilePath, frameworks, extraBuildSettings } = nse;
 
   const copiedFiles: string[] = [];
 
@@ -162,7 +162,8 @@ const withNseTarget: ConfigPlugin<PluginProps> = (
       NseUtils.generateInfoPlist(
         config.modRequest.projectRoot,
         bundleName,
-        config.ios?.buildNumber
+        config.version,
+        config.ios?.buildNumber,
       );
       NseUtils.generateEntitlements(
         config.modRequest.projectRoot,
@@ -196,7 +197,8 @@ const withNseTarget: ConfigPlugin<PluginProps> = (
       appBundleIdentifier
     );
     XcodeUtils.addBuildPhases(project, targetId, copiedFiles);
-    XcodeUtils.configureBuildSettings(project, bundleName, config.name);
+    XcodeUtils.configureBuildSettings(project, bundleName, config.name, config.ios?.appleTeamId, extraBuildSettings);
+    XcodeUtils.linkFrameworks(project, targetId, frameworks);
 
     return config;
   });

--- a/plugin/src/utils/constants.ts
+++ b/plugin/src/utils/constants.ts
@@ -23,5 +23,11 @@ export const NSE = {
   TARGET_TYPE: "app_extension",
 } as const;
 
+export const STATIC_BUILD_SETTINGS = {
+  PODS_ROOT: "\"${SRCROOT}/Pods\"",
+} as const;
+
 export const DEFAULT_IPHONEOS_DEPLOYMENT_TARGET = "12.0";
 export const DEFAULT_MARKETING_VERSION = "1.0";
+
+export const ALWAYS_REQUIRE_FRAMEWORKS = ["UserNotifications.framework"]

--- a/plugin/src/utils/nse.ts
+++ b/plugin/src/utils/nse.ts
@@ -28,11 +28,12 @@ export const copyImplementationFile = (
 export const generateInfoPlist = (
   projectRoot: string,
   bundleName: string,
+  version?: string,
   buildNumber?: string
 ) => {
   const infoPlist = BASE_PLIST.replace(
     "__CONTENT__",
-    getInfoPlistContent(buildNumber)
+    getInfoPlistContent(version, buildNumber)
   );
 
   fs.writeFileSync(
@@ -88,7 +89,7 @@ __CONTENT__
 </dict>
 </plist>`;
 
-const getInfoPlistContent = (buildNumber?: string) => `  <key>NSExtension</key>
+const getInfoPlistContent = (version?: string, buildNumber?: string) => `  <key>NSExtension</key>
   <dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.usernotifications.service</string>
@@ -101,5 +102,7 @@ const getInfoPlistContent = (buildNumber?: string) => `  <key>NSExtension</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${version}</string>
 	<key>CFBundleVersion</key>
 	<string>${buildNumber || "1"}</string>`;

--- a/plugin/src/utils/schema.ts
+++ b/plugin/src/utils/schema.ts
@@ -29,6 +29,8 @@ export const PluginPropsSchema = z
       .object({
         mFilePath: z.union([z.string(), z.array(z.string())]).optional(),
         hFilePath: z.union([z.string(), z.array(z.string())]).optional(),
+        frameworks: z.array(z.string()).optional(),
+        extraBuildSettings: z.object({}).optional(),
         bundleName: z.string().default(NSE.BUNDLE_NAME),
       })
       .default({}),


### PR DESCRIPTION
...And Xcode 16

Very open to feedback.

I used to do these modifications in other expo plugins, but it became really messy and then the expo plugin order (withDangerousMods running deferred, specifically) made it essentially impossible. Once I migrated these features into the plugin, things became much cleaner. I'll justify the added features:

- copying in development team from main project: this is necessary when using CNG, and with the default Xcode automatic signing, is all that's needed to make a full build from CNG. It's a sensible default. If you use EAS or other downstream build automation like Fastlane, my hope is this can still be overridden as desired - I tested with Fastlane which is happy to override this since it runs after expo prebuild.
- copying in the `CFBundleShortVersionString`: after upgrading to Xcode 16, I noticed this build warning: "The CFBundleShortVersionString of an app extension must match that of its containing parent app" which this should fix.
- added frameworks: this was not necessary previously, but with Expo 53 + Xcode 16, the NSE would not build without linking in frameworks. In my case we use `["Intents.framework", "UserNotifications.framework"]` in order to use SiriKit intents, but my guess is that `UserNotifications.framework` is necessary as the default due to its use in the default impl provided here.
- added extra build settings: this is purely for addition of PODS_ROOT, which a fresh CNG build simply doesn't work without (you get a cryptic error about a build script not being able to run). I would also propose attempting to add this by default, as I've never seen it not required in my CNG project, and shouldn't harm anyone by adding where it's not used?

This could definitely benefit from testing in different project configurations. Again, open to discussion. Thank you for creating a well structured plugin that was easy to modify. Of course I'm leaving any version bump to you if you decide to incorporate this.