### PR TITLE
Adds CFBundleDisplayName to Info.plist

### DIFF
--- a/plugin/src/utils/nse.ts
+++ b/plugin/src/utils/nse.ts
@@ -88,6 +88,8 @@ const getInfoPlistContent = (version?: string, buildNumber?: string) => `  <key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>${version}</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Hi again!

I noticed that an app was failing App Store validation with the warning:

> Validation failed
> Missing Info.plist value. A value for the key 'CFBundleDisplayName' in bundle XXX.app/PlugIns/push.appex is required.

This change seemed to be all that was needed to clear validation so apologies it's a small PR!