### PR TITLE
Allow addition of arbitrary metadata to NSE's Info.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ All the options of the plugin configurable from the `app.json` / `app.config.js`
 | `nse.sourceFiles`                         | `string \| string[]`            | No           | Default Xcode's NSE content      | Path to custom source files (.swift, .m, .h) for the Notification Service Extension. Automatically enables Swift build settings when Swift files are present. |
 | `nse.bundleName`                          | `string`                        | No           | `"NotificationServiceExtension"` | The name of your Notification Service Extension target                                                                                                        |
 | `nse.frameworks`                          | `string[]`                      | No           | None                             | Additional iOS Frameworks to link with the Notification Service Extension (UserNotifications.framework always included)                                       |
-| `nse.extraBuildSettings`                  | `object`                        | No           | None                             | Additional keys/values to add to the Notification Service Extension's build settings                                                                          |
-| `nse.extraInfoPlist`                      | `object`                        | No           | None                             | Additional keys/values to add to the Notification Service Extension's Info.plist (not the main app's Info.plist)                                              |
+| `nse.extraBuildSettings`                  | `object`                        | No           | None                             | Additional string keys/values to add to the Notification Service Extension's build settings                                                                   |
+| `nse.extraInfoPlist`                      | `object`                        | No           | None                             | Additional string keys/values to add to the Notification Service Extension's Info.plist (not the main app's Info.plist)                                       |
 
 # Contributing & testing
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Advanced:
             "frameworks": ["Intents.framework"],
             "extraBuildSettings": {
               "OTHER_LDFLAGS": "$(inherited) -lstdc++"
+            },
+            "extraInfoPlist": {
+              "com.github.pawicao.app.MyMetadataKey": "value"
             }
           }
         }
@@ -87,19 +90,20 @@ Advanced:
 
 All the options of the plugin configurable from the `app.json` / `app.config.js` file are listed below:
 
-| **Property**                              | **Type**                        | **Required** | **Default**                      | **Description**                                                                                                                             |
-|-------------------------------------------|---------------------------------|--------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `mode`                                    | `"development" \| "production"` | No           | `"development"`                  | Determines the APNs environment. Use `development` for testing and `production` for App Store builds                                        |
-| `appGroup`                                | `string \| string[]`            | No           | None                             | The App Group identifier or identifiers used to share data between the main app and the NSE. Format: `group.your.bundle.id`                 |
-| `intents`                                 | `string[]`                      | No           | None                             | Registers intents for your main app in `NSUserActivityTypes`, which can be required for SiriKit integration and Communication Notifications |
-| `backgroundModes.remoteNotifications`     | `boolean`                       | No           | `true`                           | Enables remote notifications background mode in your app's capabilities (if set to false, keeps as-is)                                      |
-| `backgroundModes.fetch`                   | `boolean`                       | No           | `false`                          | Enables background fetch capability in your app's capabilities (if set to false, keeps as-is)                                               |
-| `appDelegate.remoteNotificationsDelegate` | `string`                        | No           | None                             | Custom code to be injected into the `didRegisterForRemoteNotificationsWithDeviceToken` method of your AppDelegate                           |
-| `appDelegate.imports`                     | `string \| string[]`            | No           | None                             | Additional import statements to be added to your AppDelegate                                                                                |
-| `nse.sourceFiles`                           | `string \| string[]`            | No           | Default Xcode's NSE content      | Path to custom source files (.swift, .m, .h) for the Notification Service Extension. Automatically enables Swift build settings when Swift files are present.                                                            |
-| `nse.bundleName`                          | `string`                        | No           | `"NotificationServiceExtension"` | The name of your Notification Service Extension target                                                                                      |
-| `nse.frameworks`                          | `string[]`                      | No           | None                             | Additional iOS Frameworks to link with the Notification Service Extension (UserNotifications.framework always included)                     |
-| `nse.extraBuildSettings`                  | `object`                        | No           | None                             | Additional keys/values to add to the Notification Service Extension's build settings                                                        |
+| **Property**                              | **Type**                        | **Required** | **Default**                      | **Description**                                                                                                                                               |
+|-------------------------------------------|---------------------------------|--------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `mode`                                    | `"development" \| "production"` | No           | `"development"`                  | Determines the APNs environment. Use `development` for testing and `production` for App Store builds                                                          |
+| `appGroup`                                | `string \| string[]`            | No           | None                             | The App Group identifier or identifiers used to share data between the main app and the NSE. Format: `group.your.bundle.id`                                   |
+| `intents`                                 | `string[]`                      | No           | None                             | Registers intents for your main app in `NSUserActivityTypes`, which can be required for SiriKit integration and Communication Notifications                   |
+| `backgroundModes.remoteNotifications`     | `boolean`                       | No           | `true`                           | Enables remote notifications background mode in your app's capabilities (if set to false, keeps as-is)                                                        |
+| `backgroundModes.fetch`                   | `boolean`                       | No           | `false`                          | Enables background fetch capability in your app's capabilities (if set to false, keeps as-is)                                                                 |
+| `appDelegate.remoteNotificationsDelegate` | `string`                        | No           | None                             | Custom code to be injected into the `didRegisterForRemoteNotificationsWithDeviceToken` method of your AppDelegate                                             |
+| `appDelegate.imports`                     | `string \| string[]`            | No           | None                             | Additional import statements to be added to your AppDelegate                                                                                                  |
+| `nse.sourceFiles`                         | `string \| string[]`            | No           | Default Xcode's NSE content      | Path to custom source files (.swift, .m, .h) for the Notification Service Extension. Automatically enables Swift build settings when Swift files are present. |
+| `nse.bundleName`                          | `string`                        | No           | `"NotificationServiceExtension"` | The name of your Notification Service Extension target                                                                                                        |
+| `nse.frameworks`                          | `string[]`                      | No           | None                             | Additional iOS Frameworks to link with the Notification Service Extension (UserNotifications.framework always included)                                       |
+| `nse.extraBuildSettings`                  | `object`                        | No           | None                             | Additional keys/values to add to the Notification Service Extension's build settings                                                                          |
+| `nse.extraInfoPlist`                      | `object`                        | No           | None                             | Additional keys/values to add to the Notification Service Extension's Info.plist (not the main app's Info.plist)                                              |
 
 # Contributing & testing
 

--- a/plugin/src/ios.ts
+++ b/plugin/src/ios.ts
@@ -136,7 +136,7 @@ const withRemoteNotificationsDelegate: ConfigPlugin<PluginProps> = (config, { ap
 };
 
 const withNseTarget: ConfigPlugin<PluginProps> = (config, { nse, appGroup }) => {
-  const { bundleName, sourceFiles, frameworks, extraBuildSettings } = nse;
+  const { bundleName, sourceFiles, frameworks, extraBuildSettings, extraInfoPlist } = nse;
 
   const copiedFiles: string[] = [];
 
@@ -145,7 +145,7 @@ const withNseTarget: ConfigPlugin<PluginProps> = (config, { nse, appGroup }) => 
     (config) => {
       const copySourceFile = (path: string) =>
         NseUtils.copySourceFile(config.modRequest.projectRoot, bundleName, path);
-      
+
       if (!sourceFiles || sourceFiles.length === 0) {
         copiedFiles.push(...NseUtils.copyDefaultFiles(config.modRequest.projectRoot, bundleName));
       } else {
@@ -156,7 +156,8 @@ const withNseTarget: ConfigPlugin<PluginProps> = (config, { nse, appGroup }) => 
         config.modRequest.projectRoot,
         bundleName,
         config.version,
-        config.ios?.buildNumber
+        config.ios?.buildNumber,
+        extraInfoPlist
       );
       NseUtils.generateEntitlements(config.modRequest.projectRoot, bundleName, appGroup);
 

--- a/plugin/src/utils/nse.ts
+++ b/plugin/src/utils/nse.ts
@@ -10,8 +10,16 @@ export const copySourceFile = (projectRoot: string, bundleName: string, sourceFi
 };
 
 export const copyDefaultFiles = (projectRoot: string, bundleName: string) => {
-  const headerFile = copyNseFile(projectRoot, bundleName, path.join(defaultFilesDirectory, NSE.HEADER_FILE));
-  const implementationFile = copyNseFile(projectRoot, bundleName, path.join(defaultFilesDirectory, NSE.IMPLEMENTATION_FILE));
+  const headerFile = copyNseFile(
+    projectRoot,
+    bundleName,
+    path.join(defaultFilesDirectory, NSE.HEADER_FILE)
+  );
+  const implementationFile = copyNseFile(
+    projectRoot,
+    bundleName,
+    path.join(defaultFilesDirectory, NSE.IMPLEMENTATION_FILE)
+  );
   return [headerFile, implementationFile];
 };
 
@@ -19,9 +27,17 @@ export const generateInfoPlist = (
   projectRoot: string,
   bundleName: string,
   version?: string,
-  buildNumber?: string
+  buildNumber?: string,
+  extraInfoPlist: Record<string, string> = {}
 ) => {
-  const infoPlist = BASE_PLIST.replace('__CONTENT__', getInfoPlistContent(version, buildNumber));
+  let content = getInfoPlistContent(version, buildNumber);
+  for (const [key, value] of Object.entries(extraInfoPlist)) {
+    content += `
+  <key>${key}</key>
+	<string>${value}</string>`;
+  }
+
+  const infoPlist = BASE_PLIST.replace('__CONTENT__', content);
 
   fs.writeFileSync(
     path.join(projectRoot, 'ios', bundleName, `${bundleName}${NSE.PLIST_FILE_SUFFIX}`),

--- a/plugin/src/utils/nse.ts
+++ b/plugin/src/utils/nse.ts
@@ -33,7 +33,7 @@ export const generateInfoPlist = (
   let content = getInfoPlistContent(version, buildNumber);
   for (const [key, value] of Object.entries(extraInfoPlist)) {
     content += `
-  <key>${key}</key>
+	<key>${key}</key>
 	<string>${value}</string>`;
   }
 

--- a/plugin/src/utils/schema.ts
+++ b/plugin/src/utils/schema.ts
@@ -33,7 +33,8 @@ export const PluginPropsSchema = z
       .object({
         sourceFiles: zArrayStringFuzzyOptional,
         frameworks: z.array(z.string()).optional(),
-        extraBuildSettings: z.object({}).optional(),
+        extraBuildSettings: z.record(z.string()).optional(),
+        extraInfoPlist: z.record(z.string()).optional(),
         bundleName: z.string().default(NSE.BUNDLE_NAME),
       })
       .default({}),

--- a/plugin/src/utils/schema.ts
+++ b/plugin/src/utils/schema.ts
@@ -33,8 +33,8 @@ export const PluginPropsSchema = z
       .object({
         sourceFiles: zArrayStringFuzzyOptional,
         frameworks: z.array(z.string()).optional(),
-        extraBuildSettings: z.record(z.string()).optional(),
-        extraInfoPlist: z.record(z.string()).optional(),
+        extraBuildSettings: z.record(z.string(), z.string()).optional(),
+        extraInfoPlist: z.record(z.string(), z.string()).optional(),
         bundleName: z.string().default(NSE.BUNDLE_NAME),
       })
       .default({}),

--- a/plugin/src/utils/xcode.ts
+++ b/plugin/src/utils/xcode.ts
@@ -60,7 +60,7 @@ export const configureBuildSettings = (
   bundleName: string,
   appName: string,
   developmentTeam?: string,
-  extraBuildSettings?: object,
+  extraBuildSettings?: Record<string, string>,
   hasSwiftFiles?: boolean
 ) => {
   // target name is the app name without spaces


### PR DESCRIPTION
I'm back with another silly addition!

This allows you to add any other stuff you need to the NSE's Info.plist. Of course if this were the main app's Info.plist you'd just use Expo's `withInfoPlist()`, but things are a little more complicated with the NSE. Because of plugin ordering, even `withDestructiveMod()` won't be guaranteed to run after the NSE plugin. So the simplest thing here is to roll support for this into the NSE plugin. I figure it's probably not a stretch since we already allow adding arbitrary build settings.

As always, open to any suggestions/changes, and thank you for continuing to maintain this extremely useful plugin!